### PR TITLE
Update README.md for correct template creation command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A flake template for Tidal Cycles projects is provided.
 Start a new Tidal Cycles project with the following:
 
 ```
-nix flake new --template github:mitchmindtree/tidalcycles.nix ./my-tidal-project
+nix flake new --template github:mitchmindtree/tidalcycles.nix#templates.default ./my-tidal-project
 ```
 
 By default the project will have the `tidal` devShell. `cd` into your project


### PR DESCRIPTION
Correct command to instantiate a template. This was the easy fix, a better solution would be to follow what nix expects and define a `defaultTemplate` output, but I'm lazy so I just did this. When I tried to use the command in the README, I encountered: `error: cannot find flake attribute 'github:mitchmindtree/tidalcycles.nix#defaultTemplate'` 