### PR TITLE
Guarantee availability of Tidal, SuperDirt to Vim Plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix flake check
+      - run: nix flake check --no-update-lock-file
 
   # Checks the nix formatting.
   template-fmt-check:

--- a/flake.lock
+++ b/flake.lock
@@ -96,16 +96,16 @@
     "vim-tidal-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1655623220,
-        "narHash": "sha256-A9NimlO6bdqTkt4UsWs2TaEngF8n+a7HeZ/kRh3YLos=",
+        "lastModified": 1656159485,
+        "narHash": "sha256-tB3+WDGY3OEL810Trjzm5nUpLTApVkb+M1AwbsSuyw0=",
         "owner": "mitchmindtree",
         "repo": "vim-tidal",
-        "rev": "4a98788f54ed62f39c160404fe3e58986dab958c",
+        "rev": "a15a59ccee29d2bfa4095c029177efa09a1d5c0a",
         "type": "github"
       },
       "original": {
         "owner": "mitchmindtree",
-        "ref": "flupe-vim8-terminal-rebased",
+        "ref": "superdirt-term",
         "repo": "vim-tidal",
         "type": "github"
       }


### PR DESCRIPTION
Switches to a newer branch of the `vim-tidal` plugin that supports
auto-starting SuperDirt in a terminal next to the GHCi terminal. This is
disabled by default to match the original behaviour, but can be enabled
with `let g:tidal_superdirt_enable = 1`.

Also updates the `vim-tidal` defaults to use the full paths to the Tidal
GHCi instance, Tidal boot file and superdirt-start command within the
nix store. This allows for `vim-tidal` to function even outside of the
tidal devShell.