### PR TITLE
Allow passing in custom start script as param to superdirt-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Includes the following packages:
 
 | Package | Description |
 | --- | --- |
-| `superdirt-start` | A short-hand command for starting up SuperCollider and running `SuperDirt.start;`. No need to manually install `SuperDirt` as it is provided to `sclang` via a custom `sclang_conf.yaml`. |
+| `superdirt-start` | A short-hand command for starting up SuperCollider and running `SuperDirt.start;`. No need to manually install `SuperDirt` as it is provided to `sclang` via a custom `sclang_conf.yaml`. If you want to use a custom start script (e.g. to load additional samples), you can pass its path as an argument to the command. |
 | `tidal` | A command for entering the `GHCi` interpreter initialised with [`BootTidal.hs`](https://github.com/tidalcycles/Tidal/blob/main/BootTidal.hs) and the Tidal library loaded. This is a useful repl for experimenting with Tidal. |
 | `superdirt-install` | A command for installing SuperDirt and its dependencies under the user's SuperCollider configuration (the traditional installation approach). This is currently the recommended way to provide SuperDirt to the SuperCollider IDE until [this issue](https://github.com/mitchmindtree/tidalcycles.nix/issues/3) is addressed. |
 | `vim-tidal` | This is the official [tidalcycles Vim plugin](https://github.com/tidalcycles/vim-tidal) packaged for Nix and patched to use the `tidal` command for its GHCi interpreter. |

--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,22 @@
         runtimeInputs = [supercollider];
         text = ''
           start_script="''${1:-${superdirt-start-sc}}"
+
+          if [ "$start_script" == "-h" ] || [ "$start_script" == "--help" ]; then
+            echo "Usage: superdirt-start [script]"
+            echo
+            echo "Start superdirt, optionally running a custom start script."
+            echo
+            echo "Options:"
+            echo "  -h --help    Show this screen."
+            exit
+          fi
+
+          if [ ! -e "$start_script" ]; then
+            echo "The script \"$start_script\" does not exist, aborting."
+            exit 1
+          fi
+
           ${sclang-with-superdirt}/bin/sclang-with-superdirt "$start_script"
         '';
       };

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,8 @@
         name = "superdirt-start";
         runtimeInputs = [supercollider];
         text = ''
-          ${sclang-with-superdirt}/bin/sclang-with-superdirt ${superdirt-start-sc}
+          start_script="''${1:-${superdirt-start-sc}}"
+          ${sclang-with-superdirt}/bin/sclang-with-superdirt "$start_script"
         '';
       };
 


### PR DESCRIPTION
Heya! I just started playing around with tidalcycles and was wondering how I'd load up custom samples with this flake. I saw #2 and gave this a shot in this PR. It's backwards-compatible but allows passing in a custom script for startup as the first argument to `superdirt-start`. If no argument is given it behaves the same as before and loads the simple start script that just contains `SuperDirt.start;`.

It's a simple solution that I think could work? Thanks for providing this, it was a great help in getting started!