### PR TITLE
FIX: Updated flake inputs to add qt-wayland support for superdirt

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "dirt-samples-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1698439458,
-        "narHash": "sha256-Mp8qBpsOvW9Zguv95Kv7EU6S3ICaF2aO02Wz6xGURtE=",
+        "lastModified": 1742324136,
+        "narHash": "sha256-OzVvy/L6jfEgGx3dMdhe/PkfMAWVV0HQ9wGy500++fw=",
         "owner": "tidalcycles",
         "repo": "dirt-samples",
-        "rev": "9a6dff8f9ec3cd55b287290cf04e01afa6b8f532",
+        "rev": "c74fc80f8db8038f6a33648ffef5ac00a07ad402",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722813957,
-        "narHash": "sha256-IAoYyYnED7P8zrBFMnmp7ydaJfwTnwcnqxUElC1I26Y=",
+        "lastModified": 1762111121,
+        "narHash": "sha256-4vhDuZ7OZaZmKKrnDpxLZZpGIJvAeMtK6FKLJYUtAdw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cb9a96f23c491c081b38eab96d22fa958043c9fa",
+        "rev": "b3d51a0365f6695e7dd5cdf3e180604530ed33b4",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
     "superdirt-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1697377840,
-        "narHash": "sha256-9qU9CHYAXbN1IE3xXDqGipuroifVaSVXj3c/cDfwM80=",
+        "lastModified": 1760195043,
+        "narHash": "sha256-yQqbaUhQiXt4xtn70fO/mDlL2UYDTsrgO3w0rsTdcg8=",
         "owner": "musikinformatik",
         "repo": "superdirt",
-        "rev": "c7f32998572984705d340e7c1b9ed9ad998a39b6",
+        "rev": "6e6779f99062cce67761934e6dcc44c2b68fc56d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
As described in #25, the superdirt scripts currently don't work on wayland platforms without updating the inputs of the flake. This fixes that.